### PR TITLE
Remove Android Beam

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ Writing NFC tags on iOS uses the same [nfc.write](#nfcwrite) function as other p
 - [nfc.share](#nfcshare)
 - [nfc.unshare](#nfcunshare)
 - [nfc.erase](#nfcerase)
-- [nfc.handover](#nfchandover)
-- [nfc.stopHandover](#nfcstophandover)
 - [nfc.enabled](#nfcenabled)
 - [nfc.showSettings](#nfcshowsettings)
 - [~~nfc.beginSession~~](#nfcbeginsession)
@@ -452,7 +450,6 @@ Function `nfc.share` writes an NdefMessage via peer-to-peer.  This should appear
 
 ### Supported Platforms
 
-- Android
 - Windows
 - BlackBerry 7
 - BlackBerry 10
@@ -481,7 +478,6 @@ Function `nfc.unshare` stops sharing data via peer-to-peer.
 
 ### Supported Platforms
 
-- Android
 - Windows
 - BlackBerry 7
 - BlackBerry 10
@@ -507,57 +503,6 @@ This method *must* be called from within an NDEF Event Handler.
 
 - Android
 - BlackBerry 7
-
-## nfc.handover
-
-Send a file to another device via NFC handover.
-
-    var uri = "content://media/external/audio/media/175";
-    nfc.handover(uri, [onSuccess], [onFailure]);
-
-
-    var uris = [
-        "content://media/external/audio/media/175",
-        "content://media/external/audio/media/176",
-        "content://media/external/audio/media/348"
-    ];
-    nfc.handover(uris, [onSuccess], [onFailure]);
-
-
-### Parameters
-
-- __uri__: A URI as a String, or an *array* of URIs.
-- __onSuccess__: (Optional) The callback that is called when the message is pushed.
-- __onFailure__: (Optional) The callback that is called if there was an error.
-
-### Description
-
-Function `nfc.handover` shares files to a NFC peer using handover. Files are sent by specifying a file:// or context:// URI or a list of URIs. The file transfer is initiated with NFC but the transfer is completed with over Bluetooth or WiFi which is handled by a NFC handover request. The Android code is responsible for building the handover NFC Message.
-
-This is Android only, but it should be possible to add implementations for other platforms.
-
-### Supported Platforms
-
-- Android
-
-## nfc.stopHandover
-
-Stop sharing NDEF data via NFC handover.
-
-    nfc.stopHandover([onSuccess], [onFailure]);
-
-### Parameters
-
-- __onSuccess__: (Optional) The callback that is called when sharing stops.
-- __onFailure__: (Optional) The callback that is called if there was an error.
-
-### Description
-
-Function `nfc.stopHandover` stops sharing data via peer-to-peer.
-
-### Supported Platforms
-
-- Android
 
 ## nfc.showSettings
 
@@ -747,7 +692,6 @@ Use [scanNdef](#nfcscanndef) for reading NFC tags on iOS unless you need to get 
 
 - iOS
 
-
 ## nfc.cancelScan
 
 Invalidate the NFC session started by `scanNdef` or `scanTag`.
@@ -772,7 +716,6 @@ Function `cancelScan` stops the [NFCReaderSession](https://developer.apple.com/d
 ### Supported Platforms
 
 - iOS
-
 
 # Reader Mode Functions
 
@@ -849,7 +792,6 @@ Disable NFC reader mode.
 ### Supported Platforms
 
 - Android
-
 
 # Tag Technology Functions
 

--- a/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
+++ b/src/android/src/com/chariotsolutions/nfc/plugin/NfcPlugin.java
@@ -21,12 +21,10 @@ import android.app.PendingIntent;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.IntentFilter.MalformedMimeTypeException;
-import android.net.Uri;
 import android.nfc.FormatException;
 import android.nfc.NdefMessage;
 import android.nfc.NdefRecord;
 import android.nfc.NfcAdapter;
-import android.nfc.NfcEvent;
 import android.nfc.Tag;
 import android.nfc.TagLostException;
 import android.nfc.tech.Ndef;
@@ -37,7 +35,7 @@ import android.os.Handler;
 import android.os.Parcelable;
 import android.util.Log;
 
-public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCompleteCallback {
+public class NfcPlugin extends CordovaPlugin {
     private static final String REGISTER_MIME_TYPE = "registerMimeType";
     private static final String REMOVE_MIME_TYPE = "removeMimeType";
     private static final String REGISTER_NDEF = "registerNdef";
@@ -48,10 +46,6 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
     private static final String WRITE_TAG = "writeTag";
     private static final String MAKE_READ_ONLY = "makeReadOnly";
     private static final String ERASE_TAG = "eraseTag";
-    private static final String SHARE_TAG = "shareTag";
-    private static final String UNSHARE_TAG = "unshareTag";
-    private static final String HANDOVER = "handover"; // Android Beam
-    private static final String STOP_HANDOVER = "stopHandover";
     private static final String ENABLED = "enabled";
     private static final String INIT = "init";
     private static final String SHOW_SETTINGS = "showSettings";
@@ -76,21 +70,16 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
     private static final String STATUS_NFC_OK = "NFC_OK";
     private static final String STATUS_NO_NFC = "NO_NFC";
     private static final String STATUS_NFC_DISABLED = "NFC_DISABLED";
-    private static final String STATUS_NDEF_PUSH_DISABLED = "NDEF_PUSH_DISABLED";
-
     private static final String TAG = "NfcPlugin";
     private final List<IntentFilter> intentFilters = new ArrayList<>();
     private final ArrayList<String[]> techLists = new ArrayList<>();
 
-    private NdefMessage p2pMessage = null;
     private PendingIntent pendingIntent = null;
 
     private Intent savedIntent = null;
 
     private CallbackContext readerModeCallback;
     private CallbackContext channelCallback;
-    private CallbackContext shareTagCallback;
-    private CallbackContext handoverCallback;
 
     private PostponedPluginResult postponedPluginResult = null;
 
@@ -172,18 +161,6 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
 
         } else if (action.equalsIgnoreCase(ERASE_TAG)) {
             eraseTag(callbackContext);
-
-        } else if (action.equalsIgnoreCase(SHARE_TAG)) {
-            shareTag(data, callbackContext);
-
-        } else if (action.equalsIgnoreCase(UNSHARE_TAG)) {
-            unshareTag(callbackContext);
-
-        } else if (action.equalsIgnoreCase(HANDOVER)) {
-            handover(data, callbackContext);
-
-        } else if (action.equalsIgnoreCase(STOP_HANDOVER)) {
-            stopHandover(callbackContext);
 
         } else if (action.equalsIgnoreCase(INIT)) {
             init(callbackContext);
@@ -319,13 +296,6 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
     private void removeNdef(CallbackContext callbackContext) {
         removeTechList(new String[]{Ndef.class.getName()});
         restartNfc();
-        callbackContext.success();
-    }
-
-    private void unshareTag(CallbackContext callbackContext) {
-        p2pMessage = null;
-        stopNdefPush();
-        shareTagCallback = null;
         callbackContext.success();
     }
 
@@ -471,35 +441,6 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
         });
     }
 
-    private void shareTag(JSONArray data, CallbackContext callbackContext) throws JSONException {
-        NdefRecord[] records = Util.jsonToNdefRecords(data.getString(0));
-        this.p2pMessage = new NdefMessage(records);
-
-        startNdefPush(callbackContext);
-    }
-
-    // setBeamPushUris
-    // Every Uri you provide must have either scheme 'file' or scheme 'content'.
-    // Note that this takes priority over setNdefPush
-    //
-    // See http://developer.android.com/reference/android/nfc/NfcAdapter.html#setBeamPushUris(android.net.Uri[],%20android.app.Activity)
-    private void handover(JSONArray data, CallbackContext callbackContext) throws JSONException {
-
-        Uri[] uri = new Uri[data.length()];
-
-        for (int i = 0; i < data.length(); i++) {
-            uri[i] = Uri.parse(data.getString(i));
-        }
-
-        startNdefBeam(callbackContext, uri);
-    }
-
-    private void stopHandover(CallbackContext callbackContext) {
-        stopNdefBeam();
-        handoverCallback = null;
-        callbackContext.success();
-    }
-
     private void showSettings(CallbackContext callbackContext) {
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN) {
             Intent intent = new Intent(android.provider.Settings.ACTION_NFC_SETTINGS);
@@ -584,9 +525,6 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
                         nfcAdapter.enableForegroundDispatch(getActivity(), getPendingIntent(), intentFilters, techLists);
                     }
 
-                    if (p2pMessage != null) {
-                        nfcAdapter.setNdefPushMessage(p2pMessage, getActivity());
-                    }
                 } catch (IllegalStateException e) {
                     // issue 110 - user exits app with home button while nfc is initializing
                     Log.w(TAG, "Illegal State Exception starting NFC. Assuming application is terminating.");
@@ -610,77 +548,6 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
                     Log.w(TAG, "Illegal State Exception stopping NFC. Assuming application is terminating.");
                 }
             }
-        });
-    }
-
-    private void startNdefBeam(final CallbackContext callbackContext, final Uri[] uris) {
-        getActivity().runOnUiThread(() -> {
-
-            NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(getActivity());
-
-            if (nfcAdapter == null) {
-                callbackContext.error(STATUS_NO_NFC);
-            } else if (!nfcAdapter.isNdefPushEnabled()) {
-                callbackContext.error(STATUS_NDEF_PUSH_DISABLED);
-            } else {
-                nfcAdapter.setOnNdefPushCompleteCallback(NfcPlugin.this, getActivity());
-                try {
-                    nfcAdapter.setBeamPushUris(uris, getActivity());
-
-                    PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
-                    result.setKeepCallback(true);
-                    handoverCallback = callbackContext;
-                    callbackContext.sendPluginResult(result);
-
-                } catch (IllegalArgumentException e) {
-                    callbackContext.error(e.getMessage());
-                }
-            }
-        });
-    }
-
-    private void startNdefPush(final CallbackContext callbackContext) {
-        getActivity().runOnUiThread(() -> {
-
-            NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(getActivity());
-
-            if (nfcAdapter == null) {
-                callbackContext.error(STATUS_NO_NFC);
-            } else if (!nfcAdapter.isNdefPushEnabled()) {
-                callbackContext.error(STATUS_NDEF_PUSH_DISABLED);
-            } else {
-                nfcAdapter.setNdefPushMessage(p2pMessage, getActivity());
-                nfcAdapter.setOnNdefPushCompleteCallback(NfcPlugin.this, getActivity());
-
-                PluginResult result = new PluginResult(PluginResult.Status.NO_RESULT);
-                result.setKeepCallback(true);
-                shareTagCallback = callbackContext;
-                callbackContext.sendPluginResult(result);
-            }
-        });
-    }
-
-    private void stopNdefPush() {
-        getActivity().runOnUiThread(() -> {
-
-            NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(getActivity());
-
-            if (nfcAdapter != null) {
-                nfcAdapter.setNdefPushMessage(null, getActivity());
-            }
-
-        });
-    }
-
-    private void stopNdefBeam() {
-        getActivity().runOnUiThread(() -> {
-
-            NfcAdapter nfcAdapter = NfcAdapter.getDefaultAdapter(getActivity());
-
-            if (nfcAdapter != null) {
-                nfcAdapter.setBeamPushUris(null, getActivity());
-            }
-
         });
     }
 
@@ -878,21 +745,6 @@ public class NfcPlugin extends CordovaPlugin implements NfcAdapter.OnNdefPushCom
         getActivity().setIntent(intent);
     }
 
-    @Override
-    public void onNdefPushComplete(NfcEvent event) {
-
-        // handover (beam) take precedence over share tag (ndef push)
-        if (handoverCallback != null) {
-            PluginResult result = new PluginResult(PluginResult.Status.OK, "Beamed Message to Peer");
-            result.setKeepCallback(true);
-            handoverCallback.sendPluginResult(result);
-        } else if (shareTagCallback != null) {
-            PluginResult result = new PluginResult(PluginResult.Status.OK, "Shared Message with Peer");
-            result.setKeepCallback(true);
-            shareTagCallback.sendPluginResult(result);
-        }
-
-    }
 
     /**
      * Enable I/O operations to the tag from this TagTechnology object.

--- a/www/phonegap-nfc.js
+++ b/www/phonegap-nfc.js
@@ -461,18 +461,6 @@ var nfc = {
         cordova.exec(win, fail, "NfcPlugin", "unshareTag", []);
     },
 
-    handover: function (uris, win, fail) {
-        // if we get a single URI, wrap it in an array
-        if (!Array.isArray(uris)) {
-            uris = [ uris ];
-        }
-        cordova.exec(win, fail, "NfcPlugin", "handover", uris);
-    },
-
-    stopHandover: function (win, fail) {
-        cordova.exec(win, fail, "NfcPlugin", "stopHandover", []);
-    },
-
     erase: function (win, fail) {
         cordova.exec(win, fail, "NfcPlugin", "eraseTag", [[]]);
     },


### PR DESCRIPTION
Required to get Android API 34 to work, as Android Beam (which was deprecated) has been removed.